### PR TITLE
Create Base Beat Saber Install Directory Reference File

### DIFF
--- a/Vivify/Vivify.csproj.user
+++ b/Vivify/Vivify.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<BeatSaberDir><!-- Path to your Beat Saber install root folder --></BeatSaberDir>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR aims to create a base `Vivify.csproj.user` file that is used to create the reference to the `BeatSaberDir` ItemGroup reference in the `Vivify.csproj` file. This serves as a file that must be populated upon cloning and the project setup process.

Along with this change will soon come a README change with information on cloning and contribution guidelines such as styling and alike.