### PR TITLE
Replace Graphics.Blit with Command Buffers

### DIFF
--- a/Vivify/Events/ApplyPostProcessing.cs
+++ b/Vivify/Events/ApplyPostProcessing.cs
@@ -77,12 +77,7 @@ internal class ApplyPostProcessing : ICustomEvent
             }
         }
 
-        List<MaterialData> effects = data.Order switch
-        {
-            PostProcessingOrder.BeforeMainEffect => _cameraEffectApplier.PreEffects,
-            PostProcessingOrder.AfterMainEffect => _cameraEffectApplier.PostEffects,
-            _ => throw new ArgumentOutOfRangeException()
-        };
+        List<MaterialData> effects = _cameraEffectApplier.Effects[data.Order];
 
         if (duration == 0)
         {

--- a/Vivify/HarmonyPatches/CameraEffectApplier.cs
+++ b/Vivify/HarmonyPatches/CameraEffectApplier.cs
@@ -34,15 +34,21 @@ internal class CameraEffectApplier : IAffinity, IDisposable
             n => n.eventType == VivifyController.DECLARE_CULLING_TEXTURE)
             ? 1
             : 0;
+
+        foreach (PostProcessingOrder key in Enum.GetValues(typeof(PostProcessingOrder)))
+        {
+            if (!Effects.ContainsKey(key))
+            {
+                Effects[key] = [];
+            }
+        }
     }
 
     internal Dictionary<string, CreateCameraData> CameraDatas { get; } = new();
 
     internal Dictionary<string, CreateScreenTextureData> DeclaredTextureDatas { get; } = new();
 
-    internal List<MaterialData> PreEffects { get; } = [];
-
-    internal List<MaterialData> PostEffects { get; } = [];
+    internal Dictionary<PostProcessingOrder, List<MaterialData>> Effects { get; } = new();
 
     public void Dispose()
     {
@@ -64,8 +70,10 @@ internal class CameraEffectApplier : IAffinity, IDisposable
         CameraDatas.Clear();
         DeclaredTextureDatas.Clear();
 
-        PreEffects.Clear();
-        PostEffects.Clear();
+        foreach (var materials in Effects.Values)
+        {
+            materials.Clear();
+        }
     }
 
     [AffinityPrefix]
@@ -86,8 +94,7 @@ internal class CameraEffectApplier : IAffinity, IDisposable
         _postProcessingControllers[__instance] = postProcessingController;
         postProcessingController.CameraDatas = CameraDatas;
         postProcessingController.DeclaredTextureDatas = DeclaredTextureDatas;
-        postProcessingController.PreEffects = PreEffects;
-        postProcessingController.PostEffects = PostEffects;
+        postProcessingController.Effects = Effects;
         postProcessingController.PrewarmCameras(_prewarmCount);
     }
 }

--- a/Vivify/HeckImplementation/CustomDataTypes.cs
+++ b/Vivify/HeckImplementation/CustomDataTypes.cs
@@ -16,6 +16,12 @@ namespace Vivify;
 
 internal enum PostProcessingOrder
 {
+    BeforeSkybox,
+    AfterSkybox,
+    BeforeOpaque,
+    AfterOpaque,
+    BeforeAlpha,
+    AfterAlpha,
     BeforeMainEffect,
     AfterMainEffect
 }

--- a/Vivify/PostProcessing/CullingCameraController.cs
+++ b/Vivify/PostProcessing/CullingCameraController.cs
@@ -49,7 +49,7 @@ internal class CullingCameraController : MonoBehaviour
         }
     }
 
-    private void OnPostRender()
+    protected virtual void OnPostRender()
     {
         if (_cachedMask != null)
         {

--- a/Vivify/PostProcessing/PostProcessingController.cs
+++ b/Vivify/PostProcessing/PostProcessingController.cs
@@ -6,6 +6,7 @@ using IPA.Utilities;
 using JetBrains.Annotations;
 using SiraUtil.Logging;
 using UnityEngine;
+using UnityEngine.Rendering;
 using Zenject;
 using static Vivify.VivifyController;
 
@@ -155,7 +156,7 @@ internal class PostProcessingController : CullingCameraController
         RenderTextureDescriptor descriptor = src.descriptor;
         descriptor.msaaSamples = 1;
         RenderTexture temp = RenderTexture.GetTemporary(descriptor);
-        RenderImage(src, temp, PreEffects);
+        Graphics.ExecuteCommandBuffer(RenderImage(descriptor, src, temp, PreEffects));
 
         ImageEffectController.RenderImageCallback? callback = _imageEffectController._renderImageCallback;
         if (callback != null && _imageEffectController.isActiveAndEnabled)
@@ -166,7 +167,7 @@ internal class PostProcessingController : CullingCameraController
             temp = temp2;
         }
 
-        RenderImage(temp, dst, PostEffects);
+        Graphics.ExecuteCommandBuffer(RenderImage(descriptor, temp, dst, PostEffects));
         RenderTexture.ReleaseTemporary(temp);
     }
 
@@ -254,20 +255,25 @@ internal class PostProcessingController : CullingCameraController
         }
     }
 
-    private void RenderImage(RenderTexture src, RenderTexture dst, List<MaterialData> materials)
+    private CommandBuffer RenderImage(RenderTextureDescriptor mainDescriptor, RenderTargetIdentifier src, RenderTargetIdentifier dst, List<MaterialData> materials)
     {
-        RenderTextureDescriptor descriptor = src.descriptor;
         Camera.MonoOrStereoscopicEye stereoActiveEye = Camera.stereoActiveEye;
+        CommandBuffer command = new();
 
         if (materials.Count == 0)
         {
-            Graphics.Blit(src, dst);
-            return;
+            command.Blit(src, dst);
+            return command;
         }
 
+        int tempIDNext = 69;
+
         // blit all passes
-        RenderTexture main = RenderTexture.GetTemporary(descriptor);
-        Graphics.Blit(src, main);
+        int mainID = Shader.PropertyToID("_MainTex"); // TODO: I am not actually sure what this should be
+        RenderTargetIdentifier main = new(mainID);
+        command.GetTemporaryRT(mainID, mainDescriptor);
+
+        command.Blit(src, main);
         for (int i = materials.Count - 1; i >= 0; i--)
         {
             MaterialData materialData = materials[i];
@@ -290,10 +296,13 @@ internal class PostProcessingController : CullingCameraController
                             continue;
                         }
 
-                        RenderTexture temp = RenderTexture.GetTemporary(descriptor);
-                        Graphics.Blit(main, temp, material, materialData.Pass);
-                        RenderTexture.ReleaseTemporary(main);
+                        int tempID = ++tempIDNext;
+                        RenderTargetIdentifier temp = new(tempID);
+                        command.GetTemporaryRT(tempID, mainDescriptor);
+                        command.Blit(main, temp, material, materialData.Pass);
+                        command.ReleaseTemporaryRT(mainID);
                         main = temp;
+                        mainID = tempID;
                     }
                     else
                     {
@@ -329,11 +338,12 @@ internal class PostProcessingController : CullingCameraController
                                 continue;
                             }
 
-                            RenderTexture temp = RenderTexture.GetTemporary(source!.descriptor);
-                            temp.filterMode = source.filterMode;
-                            Graphics.Blit(source, temp, material, materialData.Pass);
-                            Graphics.Blit(temp, source);
-                            RenderTexture.ReleaseTemporary(temp);
+                            int tempID = ++tempIDNext;
+                            RenderTargetIdentifier temp = new(tempID);
+                            command.GetTemporaryRT(tempID, source!.descriptor, source.filterMode);
+                            command.Blit(source, temp, material, materialData.Pass);
+                            command.Blit(temp, source);
+                            command.ReleaseTemporaryRT(tempID);
 
                             continue;
                         }
@@ -379,26 +389,27 @@ internal class PostProcessingController : CullingCameraController
 
             continue;
 
-            static void Blit(RenderTexture? blitSrc, RenderTexture? blitDst, Material? blitMat, int blitPass)
+            void Blit(RenderTargetIdentifier? blitSrc, RenderTargetIdentifier? blitDst, Material? blitMat, int blitPass)
             {
-                if (blitDst == null || blitSrc == null)
+                if (!blitDst.HasValue || !blitSrc.HasValue)
                 {
                     return;
                 }
 
                 if (blitMat != null)
                 {
-                    Graphics.Blit(blitSrc, blitDst, blitMat, blitPass);
+                    command.Blit(blitSrc.Value, blitDst.Value, blitMat, blitPass);
                 }
                 else
                 {
-                    Graphics.Blit(blitSrc, blitDst);
+                    command.Blit(blitSrc.Value, blitDst.Value);
                 }
             }
         }
 
-        Graphics.Blit(main, dst);
-        RenderTexture.ReleaseTemporary(main);
+        command.Blit(main, dst);
+        command.ReleaseTemporaryRT(mainID);
+        return command;
     }
 
     private SecondaryCameraController CreateCamera()

--- a/Vivify/PostProcessing/PostProcessingController.cs
+++ b/Vivify/PostProcessing/PostProcessingController.cs
@@ -20,6 +20,7 @@ internal class PostProcessingController : CullingCameraController
     private readonly Dictionary<string, CullingCameraController> _cullingCameraControllers = new();
     private readonly Dictionary<string, RenderTextureHolder> _declaredTextures = new();
     private readonly Stack<SecondaryCameraController> _disabledCullingCameraControllers = new();
+    private readonly Stack<ActiveCommandBuffer> _activeCommandBuffers = new();
 
     private readonly List<CreateCameraData> _reusableCameraKeys = [];
     private readonly List<CreateScreenTextureData> _reusableDeclaredKeys = [];
@@ -34,9 +35,14 @@ internal class PostProcessingController : CullingCameraController
 
     internal Dictionary<string, CreateScreenTextureData> DeclaredTextureDatas { get; set; } = new();
 
-    internal List<MaterialData> PreEffects { get; set; } = [];
+    internal Dictionary<PostProcessingOrder, List<MaterialData>> Effects { get; set; } = new();
 
-    internal List<MaterialData> PostEffects { get; set; } = [];
+    private struct ActiveCommandBuffer
+    {
+        public CommandBuffer Command { get; set; }
+
+        public CameraEvent CameraEvent { get; set; }
+    }
 
     internal void PrewarmCameras(int count)
     {
@@ -159,7 +165,7 @@ internal class PostProcessingController : CullingCameraController
         _cachedMainDescriptor = descriptor;
         CreateDeclaredTextures(descriptor);
         RenderTexture temp = RenderTexture.GetTemporary(descriptor);
-        Graphics.ExecuteCommandBuffer(RenderImage(descriptor, src, temp, PreEffects));
+        Graphics.ExecuteCommandBuffer(RenderImage(descriptor, src, temp, Effects[PostProcessingOrder.BeforeMainEffect]));
 
         ImageEffectController.RenderImageCallback? callback = _imageEffectController._renderImageCallback;
         if (callback != null && _imageEffectController.isActiveAndEnabled)
@@ -170,7 +176,7 @@ internal class PostProcessingController : CullingCameraController
             temp = temp2;
         }
 
-        Graphics.ExecuteCommandBuffer(RenderImage(descriptor, temp, dst, PostEffects));
+        Graphics.ExecuteCommandBuffer(RenderImage(descriptor, temp, dst, Effects[PostProcessingOrder.AfterMainEffect]));
         RenderTexture.ReleaseTemporary(temp);
     }
 
@@ -221,7 +227,42 @@ internal class PostProcessingController : CullingCameraController
         if (_cachedMainDescriptor.HasValue)
         {
             CreateDeclaredTextures(_cachedMainDescriptor.Value);
+
+            RenderTargetIdentifier src = new(BuiltinRenderTextureType.CurrentActive);
+            RenderTargetIdentifier dst = new(BuiltinRenderTextureType.CameraTarget);
+
+            AddCommandBuffer(PostProcessingOrder.BeforeSkybox, CameraEvent.BeforeSkybox);
+            AddCommandBuffer(PostProcessingOrder.AfterSkybox, CameraEvent.AfterSkybox);
+            AddCommandBuffer(PostProcessingOrder.BeforeOpaque, CameraEvent.BeforeForwardOpaque);
+            AddCommandBuffer(PostProcessingOrder.AfterOpaque, CameraEvent.AfterForwardOpaque);
+            AddCommandBuffer(PostProcessingOrder.BeforeAlpha, CameraEvent.BeforeForwardAlpha);
+            AddCommandBuffer(PostProcessingOrder.AfterAlpha, CameraEvent.AfterForwardAlpha);
+
+            void AddCommandBuffer(PostProcessingOrder order, CameraEvent cameraEvent)
+            {
+                List<MaterialData> materials = Effects[order];
+
+                if (materials.Count == 0)
+                {
+                    return;
+                }
+
+                CommandBuffer command = RenderImage(_cachedMainDescriptor.Value, src, dst, materials);
+                Camera.AddCommandBuffer(cameraEvent, command);
+                _activeCommandBuffers.Push(new ActiveCommandBuffer
+                {
+                    CameraEvent = cameraEvent,
+                    Command = command
+                });
+            }
         }
+    }
+
+    protected override void OnPostRender()
+    {
+        ClearActiveCommandBuffers();
+
+        base.OnPostRender();
     }
 
     private void CreateDeclaredTextures(RenderTextureDescriptor descriptor)
@@ -429,6 +470,16 @@ internal class PostProcessingController : CullingCameraController
         return result;
     }
 
+    private void ClearActiveCommandBuffers()
+    {
+        while (_activeCommandBuffers.Count > 0)
+        {
+            ActiveCommandBuffer cmd = _activeCommandBuffers.Pop();
+            Camera.RemoveCommandBuffer(cmd.CameraEvent, cmd.Command);
+            cmd.Command.Dispose();
+        }
+    }
+
     [UsedImplicitly]
     [Inject]
     private void Construct(SiraLog log, IInstantiator instantiator)
@@ -440,6 +491,14 @@ internal class PostProcessingController : CullingCameraController
     private void Awake()
     {
         _imageEffectController = GetComponent<ImageEffectController>();
+
+        foreach (PostProcessingOrder key in Enum.GetValues(typeof(PostProcessingOrder)))
+        {
+            if (!Effects.ContainsKey(key))
+            {
+                Effects[key] = [];
+            }
+        }
     }
 
     private void OnDestroy()
@@ -465,6 +524,7 @@ internal class PostProcessingController : CullingCameraController
 
         _cullingCameraControllers.Clear();
         _disabledCullingCameraControllers.Clear();
+        ClearActiveCommandBuffers();
     }
 }
 

--- a/Vivify/PostProcessing/PostProcessingController.cs
+++ b/Vivify/PostProcessing/PostProcessingController.cs
@@ -28,6 +28,7 @@ internal class PostProcessingController : CullingCameraController
     private IInstantiator _instantiator = null!;
 
     private ImageEffectController _imageEffectController = null!;
+    private RenderTextureDescriptor? _cachedMainDescriptor;
 
     internal Dictionary<string, CreateCameraData> CameraDatas { get; set; } = new();
 
@@ -155,6 +156,8 @@ internal class PostProcessingController : CullingCameraController
     {
         RenderTextureDescriptor descriptor = src.descriptor;
         descriptor.msaaSamples = 1;
+        _cachedMainDescriptor = descriptor;
+        CreateDeclaredTextures(descriptor);
         RenderTexture temp = RenderTexture.GetTemporary(descriptor);
         Graphics.ExecuteCommandBuffer(RenderImage(descriptor, src, temp, PreEffects));
 
@@ -215,8 +218,10 @@ internal class PostProcessingController : CullingCameraController
             }
         }
 
-        RenderTextureDescriptor descriptor = new(Camera.pixelWidth, Camera.pixelHeight);
-        CreateDeclaredTextures(descriptor);
+        if (_cachedMainDescriptor.HasValue)
+        {
+            CreateDeclaredTextures(_cachedMainDescriptor.Value);
+        }
     }
 
     private void CreateDeclaredTextures(RenderTextureDescriptor descriptor)

--- a/Vivify/PostProcessing/PostProcessingController.cs
+++ b/Vivify/PostProcessing/PostProcessingController.cs
@@ -154,7 +154,6 @@ internal class PostProcessingController : CullingCameraController
     {
         RenderTextureDescriptor descriptor = src.descriptor;
         descriptor.msaaSamples = 1;
-        CreateDeclaredTextures(descriptor);
         RenderTexture temp = RenderTexture.GetTemporary(descriptor);
         RenderImage(src, temp, PreEffects);
 
@@ -214,6 +213,9 @@ internal class PostProcessingController : CullingCameraController
                 Shader.SetGlobalTexture(data.PropertyId, texture);
             }
         }
+
+        RenderTextureDescriptor descriptor = new(Camera.pixelWidth, Camera.pixelHeight);
+        CreateDeclaredTextures(descriptor);
     }
 
     private void CreateDeclaredTextures(RenderTextureDescriptor descriptor)


### PR DESCRIPTION
This mod SUCKS.

Replaces `Graphics.Blit` calls with [Command Buffers](https://docs.unity3d.com/6000.4/Documentation/ScriptReference/Rendering.CommandBuffer.html). This should reduce CPU overhead by batching rendering commands to the GPU, and pave the way for URP compatability.

As a bonus, we also get some new Blit `order` entrypoints:
* `'BeforeSkybox'`
* `'AfterSkybox'`
* `'BeforeOpaque'`
* `'AfterOpaque'`
* `'BeforeAlpha'`
* `'AfterAlpha'`