### PR TITLE
Fixed TextMesh Pro causing critical error spam in 1.42.1+

### DIFF
--- a/Vivify/Controllers/CameraPropertyController.cs
+++ b/Vivify/Controllers/CameraPropertyController.cs
@@ -89,7 +89,13 @@ internal class CameraPropertyController : MonoBehaviour
 
     internal bool? BloomPrePass
     {
-        set => _bloomPrePass?.enabled = value ?? true;
+        set
+        {
+            if (_bloomPrePass != null)
+            {
+                _bloomPrePass.enabled = value ?? true;
+            }
+        }
     }
 
     internal bool? MainEffect

--- a/Vivify/Managers/AssetBundleManager.cs
+++ b/Vivify/Managers/AssetBundleManager.cs
@@ -94,9 +94,58 @@ internal class AssetBundleManager : IDisposable
         }
 
         string[] assetnames = _mainBundle.GetAllAssetNames();
+        TMPro.TMP_FontAsset fallbackFont = null;
+
         foreach (string name in assetnames)
         {
             Object asset = _mainBundle.LoadAsset(name);
+
+            // Sanitize the raw prefab asset and inject a fallback font if broken
+            if (asset is GameObject gameObject)
+            {
+                TMPro.TMP_Text[] textComponents = gameObject.GetComponentsInChildren<TMPro.TMP_Text>(true);
+                foreach (TMPro.TMP_Text textComponent in textComponents)
+                {
+                    if (textComponent.font == null || textComponent.fontSharedMaterial == null || textComponent.font.material == null)
+                    {
+                        if (fallbackFont == null)
+                        {
+                            TMPro.TMP_FontAsset[] fonts = Resources.FindObjectsOfTypeAll<TMPro.TMP_FontAsset>();
+                            foreach (TMPro.TMP_FontAsset f in fonts)
+                            {
+                                if (f.name == "Teko-Medium SDF")
+                                {
+                                    fallbackFont = f;
+                                    break;
+                                }
+                            }
+                            if (fallbackFont == null && fonts.Length > 0)
+                            {
+                                fallbackFont = fonts[0];
+                            }
+                        }
+
+                        if (fallbackFont != null)
+                        {
+                            _log.Warn($"[Vivify] Repairing broken TMPro component on raw prefab: {name} with fallback font.");
+                            textComponent.font = fallbackFont;
+                            textComponent.fontSharedMaterial = fallbackFont.material;
+
+                            textComponent.textWrappingMode = TMPro.TextWrappingModes.Normal;
+                            textComponent.overflowMode = TMPro.TextOverflowModes.Overflow;
+
+                            textComponent.SetAllDirty();
+                            textComponent.ForceMeshUpdate(true);
+                        }
+                        else
+                        {
+                            _log.Warn($"[Vivify] Stripping broken TMPro component from raw asset bundle prefab: {name} (No fallback available)");
+                            Object.DestroyImmediate(textComponent, true);
+                        }
+                    }
+                }
+            }
+
             _assets.Add(name, asset);
         }
 

--- a/Vivify/ObjectPrefab/Hijackers/SaberTrailHijacker.cs
+++ b/Vivify/ObjectPrefab/Hijackers/SaberTrailHijacker.cs
@@ -39,7 +39,11 @@ internal class SaberTrailHijacker : IHijacker<FollowedSaberTrail>
             Color color = colorManager.ColorForSaberType(saber.saberType);
             saberTrail.Setup(color, saber._movementData);
             saberTrail.enabled = true;
-            saberTrail._trailRenderer?._meshRenderer.enabled = false;
+
+            if (saberTrail._trailRenderer != null && saberTrail._trailRenderer._meshRenderer != null)
+            {
+                saberTrail._trailRenderer._meshRenderer.enabled = false;
+            }
         }
         else
         {


### PR DESCRIPTION
I fixed this by by having a fallback font so the text appears in the Teko-Medium font instead of nothing.
While this isn't a perfect solution it prevents a console spam of critical errors and allows vivify to have a fallback for text.

I also fixed CS0131 errors in `CameraPropertyController.cs` and `SaberTrailHijacker.cs` so i could get the project to build.